### PR TITLE
agda Setup

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,3 +9,5 @@ packages:
   laborations/lab2/haskell
   laborations/lab3/haskell
   laborations/lab4/haskell
+
+  laborations/lab2/agda

--- a/laborations/lab2/agda/Main.hs
+++ b/laborations/lab2/agda/Main.hs
@@ -1,0 +1,3 @@
+module Main (module X) where
+
+import MAlonzo.Code.Qlab2 as X (main)

--- a/laborations/lab2/agda/Setup.hs
+++ b/laborations/lab2/agda/Setup.hs
@@ -1,0 +1,36 @@
+-- Programming Language Technology (Chalmers DAT151 / GU DIT231).
+-- (C) Andreas Abel 2023
+-- All rights reserved.
+
+-- | Hook BNFC into the cabal build process to generate AST, lexer, parser, and printer definitions.
+
+import Distribution.Simple            (defaultMainWithHooks, simpleUserHooks, buildHook)
+import Distribution.Simple.BuildPaths (autogenPackageModulesDir)
+import System.Process                 (callProcess)
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+  { buildHook = \ packageDescription localBuildInfo userHooks buildFlags -> do
+      -- For simplicity, generate files in build/global-autogen;
+      -- there they are available to all components of the package.
+      let dir = autogenPackageModulesDir localBuildInfo
+      callProcess "bnfc"
+        [ "-o", dir
+        , "-d"
+        , "CMM.cf"
+        ]
+      callProcess "agda"
+        [ "--ghc", "--ghc-dont-call-ghc"
+        , "src/lab2.agda"
+        ]
+      callProcess "rm"
+        [ "-rf"
+        , dir ++ "/MAlonzo"
+        ]
+      callProcess "mv"
+        [ "src/MAlonzo"
+        , dir ++ "/"
+        ]
+      -- Run the build process.
+      buildHook simpleUserHooks packageDescription localBuildInfo userHooks buildFlags
+  }

--- a/laborations/lab2/agda/package.yaml
+++ b/laborations/lab2/agda/package.yaml
@@ -25,8 +25,11 @@ tested-with:
   - GHC == 8.6.5
   - GHC == 8.4.4
 
-dependencies:
-  - base >= 4.9 && < 5
+custom-setup:
+  dependencies:
+    - Cabal >= 2.0 && < 4
+    - base >= 4.11 && < 5
+    - process
 
 executables:
   lab2:
@@ -34,13 +37,16 @@ executables:
     # files in CMM are qualified modules
     source-dirs:
       - .
-      - src
-    main: MAlonzo.Code.Qlab2
+      # - src
+    main: Main
+    generated-other-modules:
+      - MAlonzo.Code.Qlab2
     dependencies:
+      - base >= 4.11 && < 5
       - array
-      - text
       - filepath
       - process
+      - text
 
     # exclude some modules
     when:


### PR DESCRIPTION
- [ lab2, haskell ] add build-tool-depends section with BNFC
- [ labs, haskell ] drop testing with GHC < 8.4
- [ lab2, haskell ] bump lower bounds of dependencies to GHC 8.4.4
- [ labs ] JavaLabRunner: add copyright info, bump lower bounds
- [ labs, haskell ] Use Setup.hs also for labs 3 and 4, bump lower bounds
- [ labs, haskell ] test building also with stack
- [ www ] remove unused `include.html`
- [ labs ] overview page
- [ labs ] 2021 -> 2023
- [ deploy ] Don't add `make test` to workflow
- [ haskell-ci ] include all Haskell stubs and some testsuite
- [ lab2, agda ] use `Setup.hs` to call `agda --ghc`
